### PR TITLE
Add type def file and fix bug in getElement

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,10 @@ const getElement = (sign, language) => {
 		elementsData = require('./locales/en/elements.json');
 	}
 
-	sign.element = elementsData[sign.element];
+	// Ensure the element key exists in the elementsData
+  if (elementsData[sign.element]) {
+    sign.element = elementsData[sign.element];
+  }
 
 	return sign;
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "directories": {
     "test": "test"
   },
+  "types": "./types/zodiac-signs.d.ts",
   "scripts": {
     "test": "mocha"
   },

--- a/types/zodiac-signs.d.ts
+++ b/types/zodiac-signs.d.ts
@@ -1,0 +1,28 @@
+declare module "zodiac-signs" {
+  interface SignByDateParams {
+    day?: number;
+    month?: number;
+  }
+
+  interface ZodiacSign {
+    name: string;
+    symbol: string;
+    element: string;
+    dateMin: string;
+    dateMax: string;
+  }
+
+  interface ZodiacSigns {
+    getSignByDate(
+      params?: SignByDateParams,
+      language?: string,
+    ): ZodiacSign | number;
+    getSignByName(signName: string, language?: string): ZodiacSign | number;
+    getSignBySymbol(signSymbol: string, language?: string): ZodiacSign | number;
+    getSymbols(): string[];
+    getNames(language?: string): string[];
+    getElements(language?: string): string[];
+  }
+
+  export default function (defaultLanguage: string): ZodiacSigns;
+}


### PR DESCRIPTION
We need the type def so that typescript projects don't complain about lack of types.

getElement assumes that sign.element is always an index, but we are in fact re-assigning it to be the element string itself.  So before we assign it, we check for validity.  `npm run test` actually fails because of this.

Test: npm run test