### PR TITLE
Fixed spelling for Gemini in FR

### DIFF
--- a/locales/fr/zodiac.json
+++ b/locales/fr/zodiac.json
@@ -10,7 +10,7 @@
 		"stone": "saphir"
 	},
 	"gemini": {
-		"name": "Gémaux",
+		"name": "Gémeaux",
 		"element": 2,
 		"stone": "agate"
 	},


### PR DESCRIPTION
Fixed spelling for Gemini in FR. Can be checked on the [FR Wikipedia page for Gemini](https://fr.wikipedia.org/wiki/G%C3%A9meaux_(astrologie)). 